### PR TITLE
use presigned-post

### DIFF
--- a/backend/lib/s3.py
+++ b/backend/lib/s3.py
@@ -58,13 +58,9 @@ class _S3(_AbstractS3):
         except:
             return None
 
-        resp = self.client.generate_presigned_url(
-            'get_object',
-            Params={
-                'Bucket': bucket,
-                'Key': key
-            },
-            HttpMethod='GET'
+        resp = self.client.generate_presigned_post(
+            Bucket=bucket,
+            Key=key
         )
         return resp
 


### PR DESCRIPTION
resp is a object of the form: {
   url: "url"
   fields: {
      (kvps needed for post request body)
  }
}

You can probably turn this whole thing into a json string and return it instead of the url string.